### PR TITLE
A few compile problems

### DIFF
--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -150,7 +150,7 @@ public final class PluginImpl extends Plugin {
 			addProperty(builderClass, field);
 			addWithMethod(builderClass, field);
 		}
-		addNewBuilder(clazz.implClass, builderClass);
+		addNewBuilder(clazz, builderClass);
 		addBuildMethod(clazz.implClass, builderClass, declaredFields, superclassFields);
 		return builderClass;
 	}
@@ -172,9 +172,19 @@ public final class PluginImpl extends Plugin {
 		return method;
 	}
 
-	private void addNewBuilder(JDefinedClass clazz, JDefinedClass builderClass) {
-		JMethod method = clazz.method(JMod.PUBLIC|JMod.STATIC, builderClass, Introspector.decapitalize(clazz.name()) + "Builder");
-		method.body()._return(JExpr._new(builderClass));
+	private void addNewBuilder(ClassOutline clazz, JDefinedClass builderClass) {
+                boolean superClassWithSameName = false;
+                ClassOutline superclass = clazz.getSuperClass();
+                while (superclass != null) {
+                    if (superclass.implClass.name().equals(clazz.implClass.name())) {
+                        superClassWithSameName = true;
+                    }
+                    superclass = superclass.getSuperClass();
+                }
+                if (!superClassWithSameName){
+                    JMethod method = clazz.implClass.method(JMod.PUBLIC|JMod.STATIC, builderClass, Introspector.decapitalize(clazz.implClass.name()) + "Builder");
+                    method.body()._return(JExpr._new(builderClass));
+                }
 	}
 
 	private Object addPropertyContructor(JDefinedClass clazz, FieldOutline[] declaredFields, FieldOutline[] superclassFields) {


### PR DESCRIPTION
Hi

I was trying out your XJC plugin on the schemas here:
https://www.oasis-open.org/committees/ubl/
http://docs.oasis-open.org/ubl/os-UBL-2.1/UBL-2.1.zip

And i ran into a few problems compiling the generated code.
1. An abstract class had a builder generated, so the constructor cannot be called.
2. Multiple classes with same name and in same hierarchy (in different packages) caused the static method to get the builder to not compile, because of a name clash.

I fixed the above problems by omitting generating code if it would cause a compilation problem.

Best regards
Jesper Terkelsen
