### PR TITLE
-imm-lazy-wrapping option

### DIFF
--- a/src/main/resources/com/github/sabomichal/immutablexjc/PluginImpl.properties
+++ b/src/main/resources/com/github/sabomichal/immutablexjc/PluginImpl.properties
@@ -2,6 +2,7 @@ usage=generate immutable classes.
 title=IMMUTABLE-XJC Version ${pom.version} Build ${buildNumber}
 builderUsage=generates builder class for class instance creation. Default: false
 cConstructorUsage=generates builder copy constructor. Default: false
+lazyWrappingUsage=generates collections' wrappings in their getters instead of the constructor. Default: false
 standardCtorExists=Standard constructor exists.
 builderClassExists=Inner builder class {0} exists.
 couldNotAddStdCtor=Could not add standard constructor to {0}


### PR DESCRIPTION
In trying to incorporate immutable-xjc in a project, I've encountered UnsupportedOperationExceptions of the immutable list when trying to unmarshal JAXB objects from XML.
The solution as I see it, would be to lazily wrap the collections when they are requested, keeping the fields' values as the original collections.
This is a **rough** implementation which adds the -imm-lazy-wrapping option which does just that. 
Comments welcome, hope this is of use.