### PR TITLE
"with" methods in builders which do not overwrite current value if parameter is null

### DIFF
--- a/src/main/resources/com/github/sabomichal/immutablexjc/PluginImpl.properties
+++ b/src/main/resources/com/github/sabomichal/immutablexjc/PluginImpl.properties
@@ -2,6 +2,7 @@ usage=generate immutable classes.
 title=IMMUTABLE-XJC Version ${pom.version} Build ${buildNumber}
 builderUsage=generates builder class for class instance creation. Default: false
 cConstructorUsage=generates builder copy constructor. Default: false
+withIfNotNullUsage=generates "with" methods for non-primitive fields which do not overwrite current value if parameter is null. Default: false 
 lazyWrappingUsage=generates collections' wrappings in their getters instead of the constructor. Default: false
 standardCtorExists=Standard constructor exists.
 builderClassExists=Inner builder class {0} exists.


### PR DESCRIPTION
Hi,

I came across a problem with copy constructors and functional style. Usage pattern is:

    public XY buildBasicXY() {
      return XY.xYBuilder().withA(...).withB(...).withC(...).build();
    }

    public B makeExtendedBIfExists(...) {
      return (extendedBExists()?someExtendedB():null);
    }

    XY xy=XY.xYBuilder(buildBasicXY())
      .withB(makeExtendedBIfExists(...))
      .build();

I want to replace the `B` value in `XY` - but only if exists. Problem is: the `with()` methods in the builders **always** overwrite the existing values in the builder. You have to test before calling `with` but that breaks the chained call pattern.

I've added the possibility to add an additional `withAIfNotNull(A a)` method for all non-primitive fields `A` in the generated builders. It can be enabled with the new `-imm-ifnotnull` command line option. This method only writes the new value for a field if it is not null. This way, chained `with` calls are possible again and the pattern from above is possible.

I ask you for consideration if this code and feature can be added in the official version of the immutable-xjc plugin. BTW: Thanks for developing and maintaining this plugin!

Best regards,
Dirk Hillbrecht