### PR TITLE
Fixes #54

### DIFF
--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -885,6 +885,7 @@ public final class PluginImpl extends Plugin {
         for (JFieldVar field : declaredFields) {
             String fieldName = field.name();
             clazz.fields().get(fieldName).mods().setFinal(!(leaveCollectionsMutable && isCollection(field)));
+            clazz.fields().get(fieldName).init(null); // remove field assignment
         }
     }
 

--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -897,7 +897,18 @@ public final class PluginImpl extends Plugin {
 
     private boolean isCollection(JClass clazz) {
         return clazz.owner().ref(Collection.class).isAssignableFrom(clazz) ||
-                clazz.owner().ref(Map.class).isAssignableFrom(clazz);
+                isMap(clazz);
+    }
+
+    private boolean isMap(JFieldVar field) {
+        if (field.type() instanceof JClass) {
+            return isMap((JClass) field.type());
+        }
+        return false;
+    }
+
+    private boolean isMap(JClass clazz) {
+        return clazz.equals(clazz.owner().ref(Map.class).narrow(clazz.getTypeParameters()));
     }
 
     private boolean isRequired(JFieldVar field) {

--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -595,10 +595,6 @@ public final class PluginImpl extends Plugin {
 
     private JExpression getDefensiveCopyExpression(JCodeModel codeModel, JType jType, JVar param) {
         List<JClass> typeParams = ((JClass) jType).getTypeParameters();
-        JClass typeParameter = null;
-        if (typeParams.iterator().hasNext()) {
-            typeParameter = typeParams.iterator().next();
-        }
 
         JClass newClass = null;
         if (param.type().erasure().equals(codeModel.ref(Collection.class))) {
@@ -614,8 +610,8 @@ public final class PluginImpl extends Plugin {
         } else if (param.type().erasure().equals(codeModel.ref(SortedSet.class))) {
             newClass = codeModel.ref(TreeSet.class);
         }
-        if (newClass != null && typeParameter != null) {
-            newClass = newClass.narrow(typeParameter);
+        if (newClass != null && !typeParams.isEmpty()) {
+            newClass = newClass.narrow(typeParams);
         }
         return newClass == null ? JExpr._null() : JExpr._new(newClass).arg(param);
     }
@@ -656,10 +652,6 @@ public final class PluginImpl extends Plugin {
 
     private JExpression getNewCollectionExpression(JCodeModel codeModel, JType jType) {
         List<JClass> typeParams = ((JClass) jType).getTypeParameters();
-        JClass typeParameter = null;
-        if (typeParams.iterator().hasNext()) {
-            typeParameter = typeParams.iterator().next();
-        }
 
         JClass newClass = null;
         if (jType.erasure().equals(codeModel.ref(Collection.class))) {
@@ -675,8 +667,8 @@ public final class PluginImpl extends Plugin {
         } else if (jType.erasure().equals(codeModel.ref(SortedSet.class))) {
             newClass = codeModel.ref(TreeSet.class);
         }
-        if (newClass != null && typeParameter != null) {
-            newClass = newClass.narrow(typeParameter);
+        if (newClass != null && !typeParams.isEmpty()) {
+            newClass = newClass.narrow(typeParams);
         }
 
         return newClass == null ? JExpr._null() : JExpr._new(newClass);

--- a/src/test/java/com/github/sabomichal/immutablexjc/test/TestBasic.java
+++ b/src/test/java/com/github/sabomichal/immutablexjc/test/TestBasic.java
@@ -10,6 +10,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
@@ -39,7 +40,7 @@ public class TestBasic {
         by1.add(x1);
         NameExpression y1 = new NameExpression("y");
         by1.add(y1);
-        Declaration declaration1 = new Declaration(by1, "name", "doc", "type");
+        Declaration declaration1 = new Declaration(by1, "name", new HashMap<>(),"doc", "type");
         parameter.add(declaration1);
 
         List<NameExpression> by2 = new ArrayList<>();
@@ -47,7 +48,7 @@ public class TestBasic {
         by2.add(x2);
         NameExpression y2 = new NameExpression("y");
         by2.add(y2);
-        Declaration declaration2 = new Declaration(by2, "name", "doc", "type");
+        Declaration declaration2 = new Declaration(by2, "name", new HashMap<>(), "doc", "type");
         parameter.add(declaration2);
 
         Parameters parameters = new Parameters(parameter);

--- a/src/test/xsd/basic.xsd
+++ b/src/test/xsd/basic.xsd
@@ -32,6 +32,7 @@
             <xs:element name="by" type="NameExpression" maxOccurs="unbounded" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:anyAttribute/>
     </xs:complexType>
     <xs:complexType name="NameExpression">
         <xs:attribute name="name" type="xs:string"/>


### PR DESCRIPTION
Hello!
Thanks for creating this xjc extension.

This PR fixes a few problems with "any" attributes/types and the generated field `Map<QName, String> otherAttributes` (see #54).

Changes:

- All direct/initial field assignments outside of constructors are removed when fields are made final.
- Maps are now correctly identified as Collections
- Support for multiple generic parameters on Collection fields (e.g. Maps)
- Builders should now support adding entries (key/value pairs).

Constructors with "otherAttributes" Maps now look like this:
```
public Variable(final List<NameExpression> by, final String name, final Map<QName, String> otherAttributes) {
    if (by == null) {
        this.by = null;
    } else {
        this.by = new ArrayList<NameExpression>(by);
    }
    this.name = name;
    if (otherAttributes == null) {
        this.otherAttributes = null;
    } else {
        this.otherAttributes = new HashMap<QName, String>(otherAttributes);
    }
}
```

Getters:
```
public Map<QName, String> getOtherAttributes() {
    Map<QName, String> ret;
    if (otherAttributes == null) {
        ret = Collections.emptyMap();
    } else {
        ret = Collections.unmodifiableMap(otherAttributes);
    }
    return ret;
}
```

Builders now have add methods which take multiple values for Maps (and other Collections with more than one generic parameter). The parameters have a generated suffix 0, 1, 2 to prevent name clashes:
```
public Variable.Builder addOtherAttributes(final QName otherAttributes0, final String otherAttributes1) {
    this.otherAttributes.put(otherAttributes0, otherAttributes1);
    return this;
}
```