### PR TITLE
Improvement: Fixes #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 IMMUTABLE-XJC is a JAXB 2.x XJC plugin for making schema derived classes immutable:
 
 * removes all setter methods
-* marks class final
+* marks class final (can be disabled with the '-imm-nofinalclasses' option)
 * creates a public constructor with all fields as parameters
 * creates a protected no-arg constructor
 * marks all fields within a class as final
@@ -75,6 +75,9 @@ The '-imm-constructordefaults' option is used to set default values for xs:eleme
 
 #### -imm-optionalgetter
 The '-imm-optionalgetter' option is used to wrap the return value of getters for non-required (`@XmlAttribute|Element(required = false)`) values with `java.util.Optional<OriginalRetunType>`.
+
+#### -imm-nofinalclasses
+The '-imm-nofinalclasses' option is used to leave all classes non-final.
 
 ### Usage
 #### JAXB-RI CLI

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,25 @@
                                     </args>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>test-model-nofinalclasses</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                                <configuration>
+                                    <specVersion>3.0.1</specVersion>
+                                    <schemaDirectory>src/test/xsd</schemaDirectory>
+                                    <generatePackage>${project.groupId}.immutablexjc.test.nofinalclasses</generatePackage>
+                                    <generateDirectory>target/generated-test-sources/xjc</generateDirectory>
+                                    <addTestCompileSourceRoot>true</addTestCompileSourceRoot>
+                                    <forceRegenerate>true</forceRegenerate>
+                                    <args>
+                                        <arg>-immutable</arg>
+                                        <arg>-imm-nofinalclasses</arg>
+                                    </args>
+                                </configuration>
+                            </execution>
 							<execution>
 								<id>test-model-inherit</id>
 								<phase>generate-test-sources</phase>

--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -77,7 +77,7 @@ public final class PluginImpl extends Plugin {
     private static final String OPTION_NAME = "immutable";
     private static final JType[] NO_ARGS = new JType[0];
 
-    private ResourceBundle resourceBundle = ResourceBundle.getBundle(PluginImpl.class.getCanonicalName());
+    private final ResourceBundle resourceBundle = ResourceBundle.getBundle(PluginImpl.class.getCanonicalName());
     private boolean createBuilder;
     private boolean builderInheritance;
     private boolean createCConstructor;
@@ -762,12 +762,12 @@ public final class PluginImpl extends Plugin {
     }
 
     private boolean mustAssign(JFieldVar field) {
-        // we have to assign final field, except filled collection fields, since we might loose the collection type upon marshal
+        // we have to assign final field, except filled collection fields, since we might lose the collection type upon marshal
         return !isFinal(field) || !isCollection(field) || getInitJExpression(field) == null;
     }
 
     private boolean shouldAssign(JFieldVar field) {
-        // we don't want to clear filled collection fields in default constructor, since we might loose the collection type upon marshal
+        // we don't want to clear filled collection fields in default constructor, since we might lose the collection type upon marshal
         return !isCollection(field) || getInitJExpression(field) == null;
     }
 
@@ -1058,8 +1058,8 @@ public final class PluginImpl extends Plugin {
 
     private static class ClassField {
 
-        private JDefinedClass clazz;
-        private JFieldVar field;
+        private final JDefinedClass clazz;
+        private final JFieldVar field;
 
         public ClassField(JDefinedClass clazz, JFieldVar field) {
             this.clazz = clazz;

--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -69,6 +69,7 @@ public final class PluginImpl extends Plugin {
     private static final String SKIPCOLLECTIONS_OPTION_NAME = "-imm-skipcollections";
     private static final String CONSTRUCTORDEFAULTS_OPTION_NAME = "-imm-constructordefaults";
     private static final String OPTIONAL_GETTER_OPTION_NAME = "-imm-optionalgetter";
+    private static final String NOFINALCLASSES_OPTION_NAME = "-imm-nofinalclasses";
 
     private static final String UNSET_PREFIX = "unset";
     private static final String SET_PREFIX = "set";
@@ -87,6 +88,7 @@ public final class PluginImpl extends Plugin {
     private boolean setDefaultValuesInConstructor;
     private boolean useSimpleBuilderName;
     private boolean optionalGetter;
+    private boolean noFinalClasses;
     private Options options;
 
     @Override
@@ -201,6 +203,7 @@ public final class PluginImpl extends Plugin {
         appendOption(retval, PUBLICCONSTRUCTOR_MAXARGS_OPTION_NAME, getMessage("publicConstructorMaxArgs"), n, maxOptionLength);
         appendOption(retval, CONSTRUCTORDEFAULTS_OPTION_NAME, getMessage("setDefaultValuesInConstructor"), n, maxOptionLength);
         appendOption(retval, OPTIONAL_GETTER_OPTION_NAME, getMessage("optionalGetterUsage"), n, maxOptionLength);
+        appendOption(retval, NOFINALCLASSES_OPTION_NAME, getMessage("noFinalClassesUsage"), n, maxOptionLength);
         return retval.toString();
     }
 
@@ -256,6 +259,10 @@ public final class PluginImpl extends Plugin {
         }
         if (args[i].startsWith(OPTIONAL_GETTER_OPTION_NAME)) {
             this.optionalGetter = true;
+            return 1;
+        }
+        if (args[i].startsWith(NOFINALCLASSES_OPTION_NAME)) {
+            this.noFinalClasses = true;
             return 1;
         }
         return 0;
@@ -884,7 +891,7 @@ public final class PluginImpl extends Plugin {
     }
 
     private void makeClassFinal(JDefinedClass clazz) {
-        clazz.mods().setFinal(true);
+        clazz.mods().setFinal(!noFinalClasses);
     }
 
     private void makePropertiesPrivate(JDefinedClass clazz) {

--- a/src/main/resources/com/github/sabomichal/immutablexjc/PluginImpl.properties
+++ b/src/main/resources/com/github/sabomichal/immutablexjc/PluginImpl.properties
@@ -16,3 +16,4 @@ leaveCollectionsMutable=generates code with leaves mutable collections
 publicConstructorMaxArgs=generates public constructors with maximum number of arguments
 setDefaultValuesInConstructor=sets default values for fields in no-args constructor
 optionalGetterUsage=let getters of @XmlElement/Attribute(required = false) return java.util.Optional
+noFinalClassesUsage=does not mark classes final.

--- a/src/test/java/com/github/sabomichal/immutablexjc/test/TestNoFinalClasses.java
+++ b/src/test/java/com/github/sabomichal/immutablexjc/test/TestNoFinalClasses.java
@@ -1,0 +1,97 @@
+package com.github.sabomichal.immutablexjc.test;
+
+import com.github.sabomichal.immutablexjc.test.nofinalclasses.Declaration;
+import com.github.sabomichal.immutablexjc.test.nofinalclasses.Model;
+import com.github.sabomichal.immutablexjc.test.nofinalclasses.ObjectFactory;
+import com.github.sabomichal.immutablexjc.test.nofinalclasses.Parameters;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.annotation.XmlType;
+import org.glassfish.jaxb.runtime.v2.runtime.unmarshaller.UnmarshallerImpl;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+public class TestNoFinalClasses {
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "MyDeclaration", namespace = "https://x.y.z.com/w", propOrder = {
+            "myAdditionalElement"
+    })
+    public static class MyDeclaration extends Declaration {
+
+        @XmlElement
+        private final String myAdditionalElement;
+
+        public MyDeclaration(String myAdditionalElement) {
+            super(new ArrayList<>(), "name", new HashMap<>(), "doc", "type");
+            this.myAdditionalElement = myAdditionalElement;
+        }
+
+        protected MyDeclaration() {
+            myAdditionalElement = null;
+        }
+
+        public String getMyAdditionalField() {
+            return myAdditionalElement;
+        }
+    }
+
+    @XmlRegistry
+    public static class MyFactory extends ObjectFactory {
+
+        @Override
+        public Declaration createDeclaration() {
+            return new MyDeclaration();
+        }
+    }
+
+    @Test
+    public void testUnmarshall() throws Exception {
+        JAXBContext jc = JAXBContext.newInstance(Model.class);
+        Unmarshaller unmarshaller = jc.createUnmarshaller();
+        unmarshaller.setProperty(UnmarshallerImpl.FACTORY, new MyFactory());
+        Model model = (Model) unmarshaller.unmarshal(this.getClass().getResourceAsStream("/model.xml"));
+        assertNotNull(model);
+        assertNotNull(model.getParameters());
+        assertTrue(model.getParameters().getParameter().get(0) instanceof MyDeclaration);
+        assertNull(((MyDeclaration) model.getParameters().getParameter().get(0)).myAdditionalElement);
+    }
+
+    @Test
+    public void testMarshall() throws Exception {
+        List<Declaration> parameter = new ArrayList<>();
+
+        MyDeclaration myDeclaration = new MyDeclaration("myAdditionalElement");
+        parameter.add(myDeclaration);
+
+        Parameters parameters = new Parameters(parameter);
+        Model model = new Model(parameters);
+        assertNotNull(model);
+
+        JAXBContext jc = JAXBContext.newInstance(Model.class, MyDeclaration.class);
+        Marshaller marshaller = jc.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+        marshaller.marshal(model, System.out);
+
+        try {
+            model.getParameters().getParameter().add(0, myDeclaration);
+            fail("Expected an UnsupportedOperationException to be thrown");
+        } catch (UnsupportedOperationException e) {
+            assertNotNull(e);
+        }
+    }
+}


### PR DESCRIPTION
Sometimes users can not change the XML schema but still want to extend JAXB generated classes (via code). For example to add convenience methods or even add additional fields/attributes. This can be done by extending classes with a sub type and then providing a custom ObjectFactory to the Unmarshaller. In order for this to work the classes can not be final.

This PR adds a new option '-imm-nofinalclasses' which disables the "mark classes final" feature. Additionaly it adds a new test "TestNoFinalClasses" to show a possible use-case.

Please let me know if you are happy with the change, the naming of the option and so on.