### PR TITLE
Fix abstract superclasses not being represented in the copy constructor

### DIFF
--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -806,16 +806,14 @@ public final class PluginImpl extends Plugin {
         for (JFieldVar field : superclassFields) {
             String propertyName = field.name();
             JType type = field.type();
-            if (type instanceof JDefinedClass) {
-                JMethod getter = getGetterProperty(field, clazz);
-                if (isCollection(field)) {
-                    JVar tmpVar = ctor.body().decl(0, getJavaType(field), "_" + propertyName, JExpr.invoke(o, getter));
-                    JConditional conditional = ctor.body()._if(tmpVar.eq(JExpr._null()));
-                    conditional._then().assign(JExpr.refthis(propertyName), getNewCollectionExpression(codeModel, getJavaType(field)));
-                    conditional._else().assign(JExpr.refthis(propertyName), getDefensiveCopyExpression(codeModel, getJavaType(field), tmpVar));
-                } else {
-                    ctor.body().assign(JExpr.refthis(propertyName), JExpr.invoke(o, getter));
-                }
+            JMethod getter = getGetterProperty(field, clazz);
+            if (isCollection(field)) {
+                JVar tmpVar = ctor.body().decl(0, getJavaType(field), "_" + propertyName, JExpr.invoke(o, getter));
+                JConditional conditional = ctor.body()._if(tmpVar.eq(JExpr._null()));
+                conditional._then().assign(JExpr.refthis(propertyName), getNewCollectionExpression(codeModel, getJavaType(field)));
+                conditional._else().assign(JExpr.refthis(propertyName), getDefensiveCopyExpression(codeModel, getJavaType(field), tmpVar));
+            } else {
+                ctor.body().assign(JExpr.refthis(propertyName), JExpr.invoke(o, getter));
             }
         }
         for (JFieldVar field : declaredFields) {

--- a/src/test/java/com/github/sabomichal/immutablexjc/test/TestInheritBuilder.java
+++ b/src/test/java/com/github/sabomichal/immutablexjc/test/TestInheritBuilder.java
@@ -113,4 +113,17 @@ public class TestInheritBuilder {
         assertNotNull(d2.getBy());
         assertEquals(d1.getBy(), d2.getBy());
     }
+
+    @Test
+    public void testSubclassBuilderCopiesAbstractSuperclassProperties() {
+        TidyBedroom tb1 = TidyBedroom.builder()
+                .withCost(5)
+                .withExperiencePoints(10)
+                .build();
+        TidyBedroom tb2 = TidyBedroom.builder(tb1).build();
+
+        assertNotNull(tb2);
+        assertEquals(tb1.getCost(), tb2.getCost());
+        assertEquals(tb1.getExperiencePoints(), tb2.getExperiencePoints());
+    }
 }


### PR DESCRIPTION
This commit removes the check for a superclass field being a DefinedClass. This check would prevent primitive (or other) types of superclass-fields to be added to the copy constructor.

I also added a test case for this.

This fixes #85 .