### PR TITLE
XML values are always required

### DIFF
--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -341,7 +341,7 @@ public final class PluginImpl extends Plugin {
         }
         for (JFieldVar field : declaredFields) {
             if (mustAssign(field)) {
-                if (isRequired(field)) {
+                if (isRequired(field) && !field.type().isPrimitive()) {
                     JBlock block = method.body();
                     JConditional conditional = block._if(field.eq(JExpr._null()));
                     conditional._then()._throw(JExpr._new(builderClass.owner().ref(NullPointerException.class))
@@ -939,6 +939,10 @@ public final class PluginImpl extends Plugin {
     }
 
     private boolean isRequired(JFieldVar field) {
+        if (field.type().isPrimitive()) {
+            return true;
+        }
+
         if (getAnnotation(field.annotations(), XmlValue.class.getCanonicalName()).isPresent()) {
             return true;
         }

--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -48,6 +48,7 @@ import com.sun.tools.xjc.outline.ClassOutline;
 import com.sun.tools.xjc.outline.Outline;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlValue;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.xml.sax.ErrorHandler;
@@ -938,6 +939,10 @@ public final class PluginImpl extends Plugin {
     }
 
     private boolean isRequired(JFieldVar field) {
+        if (getAnnotation(field.annotations(), XmlValue.class.getCanonicalName()).isPresent()) {
+            return true;
+        }
+
         return Stream.of(XmlElement.class, XmlAttribute.class)
                 .map(annotationType ->
                         getAnnotation(field.annotations(), annotationType.getCanonicalName())

--- a/src/test/java/com/github/sabomichal/immutablexjc/test/TestMiscOptions.java
+++ b/src/test/java/com/github/sabomichal/immutablexjc/test/TestMiscOptions.java
@@ -4,6 +4,8 @@ import com.github.sabomichal.immutablexjc.test.misc.Declaration;
 import com.github.sabomichal.immutablexjc.test.misc.Model;
 import com.github.sabomichal.immutablexjc.test.misc.NameExpression;
 import com.github.sabomichal.immutablexjc.test.misc.Parameters;
+import com.github.sabomichal.immutablexjc.test.optionalgetter.DecimalExtensionType;
+import com.github.sabomichal.immutablexjc.test.optionalgetter.NoOptionalForPrimitive;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.Marshaller;
 import org.junit.jupiter.api.Test;
@@ -103,9 +105,13 @@ public class TestMiscOptions {
                        .getDocumentation()
                        .isPresent());
 
-        com.github.sabomichal.immutablexjc.test.optionalgetter.DecimalExtensionType type = new com.github.sabomichal.immutablexjc.test.optionalgetter.DecimalExtensionType(BigDecimal.valueOf(1), "s");
+        DecimalExtensionType type = new DecimalExtensionType(BigDecimal.valueOf(1), "s");
         assertNotNull(type.getValue());
         assertEquals(BigDecimal.class, type.getValue().getClass());
         assertTrue(type.getUnit().isPresent());
+
+        NoOptionalForPrimitive primitive = new NoOptionalForPrimitive(1);
+        assertNotNull(primitive.getIndex());
+        assertEquals(1, primitive.getIndex());
     }
 }

--- a/src/test/java/com/github/sabomichal/immutablexjc/test/TestMiscOptions.java
+++ b/src/test/java/com/github/sabomichal/immutablexjc/test/TestMiscOptions.java
@@ -9,6 +9,8 @@ import jakarta.xml.bind.Marshaller;
 import org.junit.jupiter.api.Test;
 
 
+import java.math.BigDecimal;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -100,5 +102,10 @@ public class TestMiscOptions {
         assertTrue(new com.github.sabomichal.immutablexjc.test.optionalgetter.Declaration(null, null, null, "documentation", null)
                        .getDocumentation()
                        .isPresent());
+
+        com.github.sabomichal.immutablexjc.test.optionalgetter.DecimalExtensionType type = new com.github.sabomichal.immutablexjc.test.optionalgetter.DecimalExtensionType(BigDecimal.valueOf(1), "s");
+        assertNotNull(type.getValue());
+        assertEquals(BigDecimal.class, type.getValue().getClass());
+        assertTrue(type.getUnit().isPresent());
     }
 }

--- a/src/test/xsd/basic.xsd
+++ b/src/test/xsd/basic.xsd
@@ -51,4 +51,9 @@
             <xs:fractionDigits value="3"/>
         </xs:restriction>
     </xs:simpleType>
+    <xs:complexType name="NoOptionalForPrimitive">
+        <xs:sequence>
+            <xs:element name="index" type="xs:int"/>
+        </xs:sequence>
+    </xs:complexType>
 </xs:schema>

--- a/src/test/xsd/basic.xsd
+++ b/src/test/xsd/basic.xsd
@@ -37,4 +37,18 @@
     <xs:complexType name="NameExpression">
         <xs:attribute name="name" type="xs:string"/>
     </xs:complexType>
+    <xs:element name="DecimalExtensionType">
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="BaseType">
+                    <xs:attribute name="unit" fixed="s"/>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:simpleType name="BaseType">
+        <xs:restriction base="xs:decimal">
+            <xs:fractionDigits value="3"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
This is a potential fix for the issue described in #124 together with a unit test to prevent any future regressions.

fixes #124 

---

Since I just also ran into the issue with primitive fields I've added a potential fix and unit test for that to this PR as well. I decided to not make two separate PRs to prevent a potential merge conflict as both changes affect the same areas of the codebase.

fixes #107 