### PR TITLE
Cc parent optionals fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.13.0</version>
                     <configuration>
-                        <release>8</release>
                         <debug>true</debug>
                         <optimize>true</optimize>
                         <showDeprecation>true</showDeprecation>
@@ -370,6 +369,8 @@
                                     <forceRegenerate>true</forceRegenerate>
                                     <args>
                                         <arg>-Ximm</arg>
+                                        <arg>-Ximm-builder</arg>
+                                        <arg>-Ximm-cc</arg>
                                         <arg>-Ximm-optionalgetter</arg>
                                     </args>
                                 </configuration>

--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -1,47 +1,6 @@
 package com.github.sabomichal.immutablexjc;
 
-import java.beans.Introspector;
-import java.io.StringWriter;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.ResourceBundle;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.SortedSet;
-import java.util.TreeMap;
-import java.util.TreeSet;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import com.sun.codemodel.JAnnotationUse;
-import com.sun.codemodel.JAnnotationValue;
-import com.sun.codemodel.JBlock;
-import com.sun.codemodel.JClass;
-import com.sun.codemodel.JClassAlreadyExistsException;
-import com.sun.codemodel.JCodeModel;
-import com.sun.codemodel.JConditional;
-import com.sun.codemodel.JDefinedClass;
-import com.sun.codemodel.JExpr;
-import com.sun.codemodel.JExpression;
-import com.sun.codemodel.JFieldVar;
-import com.sun.codemodel.JFormatter;
-import com.sun.codemodel.JInvocation;
-import com.sun.codemodel.JMethod;
-import com.sun.codemodel.JMod;
-import com.sun.codemodel.JType;
-import com.sun.codemodel.JVar;
+import com.sun.codemodel.*;
 import com.sun.tools.xjc.Options;
 import com.sun.tools.xjc.Plugin;
 import com.sun.tools.xjc.outline.ClassOutline;
@@ -52,6 +11,15 @@ import jakarta.xml.bind.annotation.XmlValue;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.xml.sax.ErrorHandler;
+
+import java.beans.Introspector;
+import java.io.StringWriter;
+import java.text.MessageFormat;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * IMMUTABLE-XJC plugin implementation.
@@ -213,9 +181,7 @@ public final class PluginImpl extends Plugin {
     private void appendOption(StringBuilder retval, String option, String description, String n, int optionColumnWidth) {
         retval.append("  ");
         retval.append(option);
-        for (int i = option.length(); i < optionColumnWidth; i++) {
-            retval.append(' ');
-        }
+        retval.append(" ".repeat(Math.max(0, optionColumnWidth - option.length())));
         retval.append(" :  ");
         retval.append(description);
         retval.append(n);
@@ -345,7 +311,7 @@ public final class PluginImpl extends Plugin {
                     JBlock block = method.body();
                     JConditional conditional = block._if(field.eq(JExpr._null()));
                     conditional._then()._throw(JExpr._new(builderClass.owner().ref(NullPointerException.class))
-                                                   .arg("Required field '" + field.name() + "' have to be assigned a value."));
+                            .arg("Required field '" + field.name() + "' have to be assigned a value."));
                 }
                 constructorInvocation.arg(JExpr.ref(field.name()));
             }

--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -833,8 +833,10 @@ public final class PluginImpl extends Plugin {
                 JConditional conditional = ctor.body()._if(tmpVar.eq(JExpr._null()));
                 conditional._then().assign(JExpr.refthis(propertyName), getNewCollectionExpression(codeModel, getJavaType(field)));
                 conditional._else().assign(JExpr.refthis(propertyName), getDefensiveCopyExpression(codeModel, getJavaType(field), tmpVar));
-            } else {
+            } else if (isRequired(field)) {
                 ctor.body().assign(JExpr.refthis(propertyName), JExpr.ref(o, propertyName));
+            } else {
+                ctor.body().assign(JExpr.refthis(propertyName), JExpr.invoke(o, getter).invoke("orElse").arg(JExpr._null()));
             }
         }
         return ctor;

--- a/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
+++ b/src/main/java/com/github/sabomichal/immutablexjc/PluginImpl.java
@@ -786,10 +786,10 @@ public final class PluginImpl extends Plugin {
                 JConditional conditional = ctor.body()._if(tmpVar.eq(JExpr._null()));
                 conditional._then().assign(JExpr.refthis(propertyName), getNewCollectionExpression(codeModel, getJavaType(field)));
                 conditional._else().assign(JExpr.refthis(propertyName), getDefensiveCopyExpression(codeModel, getJavaType(field), tmpVar));
-            } else if (isRequired(field)) {
-                ctor.body().assign(JExpr.refthis(propertyName), JExpr.invoke(o, getter));
-            } else {
+            } else if (optionalGetter && !isRequired(field)) {
                 ctor.body().assign(JExpr.refthis(propertyName), JExpr.invoke(o, getter).invoke("orElse").arg(JExpr._null()));
+            } else {
+                ctor.body().assign(JExpr.refthis(propertyName), JExpr.invoke(o, getter));
             }
         }
         for (JFieldVar field : declaredFields) {
@@ -800,6 +800,8 @@ public final class PluginImpl extends Plugin {
                 JConditional conditional = ctor.body()._if(tmpVar.eq(JExpr._null()));
                 conditional._then().assign(JExpr.refthis(propertyName), getNewCollectionExpression(codeModel, getJavaType(field)));
                 conditional._else().assign(JExpr.refthis(propertyName), getDefensiveCopyExpression(codeModel, getJavaType(field), tmpVar));
+            } else {
+                ctor.body().assign(JExpr.refthis(propertyName), JExpr.ref(o, propertyName));
             }
         }
         return ctor;

--- a/src/test/java/com/github/sabomichal/immutablexjc/test/TestBasic.java
+++ b/src/test/java/com/github/sabomichal/immutablexjc/test/TestBasic.java
@@ -41,7 +41,7 @@ public class TestBasic {
         by1.add(x1);
         NameExpression y1 = new NameExpression("y");
         by1.add(y1);
-        Declaration declaration1 = new Declaration(by1, "name", new HashMap<>(),"doc", "type");
+        Declaration declaration1 = new Declaration(by1, "name", "comment", new HashMap<>(),"doc", "type");
         parameter.add(declaration1);
 
         List<NameExpression> by2 = new ArrayList<>();
@@ -49,7 +49,7 @@ public class TestBasic {
         by2.add(x2);
         NameExpression y2 = new NameExpression("y");
         by2.add(y2);
-        Declaration declaration2 = new Declaration(by2, "name", new HashMap<>(), "doc", "type");
+        Declaration declaration2 = new Declaration(by2, "name", "comment", new HashMap<>(), "doc", "type");
         parameter.add(declaration2);
 
         Parameters parameters = new Parameters(parameter);

--- a/src/test/java/com/github/sabomichal/immutablexjc/test/TestMiscOptions.java
+++ b/src/test/java/com/github/sabomichal/immutablexjc/test/TestMiscOptions.java
@@ -97,11 +97,11 @@ public class TestMiscOptions {
 
     @Test
     public void testOptionalGetter() {
-        assertFalse(new com.github.sabomichal.immutablexjc.test.optionalgetter.Declaration(null, null, null, null, null)
+        assertFalse(new com.github.sabomichal.immutablexjc.test.optionalgetter.Declaration(null, null,  null,null, null, null)
                         .getDocumentation()
                         .isPresent());
 
-        assertTrue(new com.github.sabomichal.immutablexjc.test.optionalgetter.Declaration(null, null, null, "documentation", null)
+        assertTrue(new com.github.sabomichal.immutablexjc.test.optionalgetter.Declaration(null, null, null, null, "documentation", null)
                        .getDocumentation()
                        .isPresent());
 

--- a/src/test/java/com/github/sabomichal/immutablexjc/test/TestNoFinalClasses.java
+++ b/src/test/java/com/github/sabomichal/immutablexjc/test/TestNoFinalClasses.java
@@ -35,7 +35,7 @@ public class TestNoFinalClasses {
         private final String myAdditionalElement;
 
         public MyDeclaration(String myAdditionalElement) {
-            super(new ArrayList<>(), "name", new HashMap<>(), "doc", "type");
+            super(new ArrayList<>(), "name", "comment", new HashMap<>(), "doc", "type");
             this.myAdditionalElement = myAdditionalElement;
         }
 

--- a/src/test/xsd/abstract.xsd
+++ b/src/test/xsd/abstract.xsd
@@ -18,6 +18,7 @@
             <xs:element name="correlation_id" type="xs:string"/>
             <xs:element name="session_id" type="xs:string"/>
             <xs:element name="return_code" type="xs:string"/>
+            <xs:element name="min_version" type="xs:string" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
     <xs:element name="body" type="body"/>

--- a/src/test/xsd/abstract.xsd
+++ b/src/test/xsd/abstract.xsd
@@ -18,7 +18,7 @@
             <xs:element name="correlation_id" type="xs:string"/>
             <xs:element name="session_id" type="xs:string"/>
             <xs:element name="return_code" type="xs:string"/>
-            <xs:element name="min_version" type="xs:string" minOccurs="0"/>
+            <xs:element name="min_version" type="xs:string"/>
         </xs:sequence>
     </xs:complexType>
     <xs:element name="body" type="body"/>

--- a/src/test/xsd/basic.xsd
+++ b/src/test/xsd/basic.xsd
@@ -32,6 +32,7 @@
             <xs:element name="by" type="NameExpression" maxOccurs="unbounded" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="comment" type="xs:string" use="optional"/>
         <xs:anyAttribute/>
     </xs:complexType>
     <xs:complexType name="NameExpression">


### PR DESCRIPTION
supports optional fields in parent classes when using the copy constructors and optional getters.

assigns a property with this.prop1 = other.getProp1().orElse(null) instead of the optional returned by the getter.